### PR TITLE
Added visual representation of channel data acquisition rate

### DIFF
--- a/ui/channeltreemodel.py
+++ b/ui/channeltreemodel.py
@@ -23,6 +23,8 @@ class ChannelNode(TreeNode):
                 return None
             elif column == 2:
                 return str(self.channel.datarate)
+            elif column == 3:
+                return str(self.channel.get_bytes_per_second() / 1024)
         elif role == Qt.CheckStateRole:
             if column == 0:
                 return Qt.Checked if self.channel.enabled else Qt.Unchecked
@@ -48,6 +50,10 @@ class ChannelNode(TreeNode):
             if column == 2:
                 try:
                     self.channel.datarate = value
+                    
+                    # update bytes per second
+                    self.data(3, Qt.DisplayRole)
+                    
                     return True
                 except DAQChannelBitrateTooHigh as e:
                     self.channel.datarate = e.maxdatarate
@@ -82,7 +88,7 @@ class ModelNode(TreeNode):
 class ChannelTreeModel(TreeModel):
     def __init__(self, models, parent=None):
         self.models = models
-        self.columns = ['Name', 'Acquire', 'Datarate']
+        self.columns = ['Name', 'Acquire', 'Samples/s', 'KiB/s']
         super(ChannelTreeModel, self).__init__(parent)
 
     def empty(self):


### PR DESCRIPTION
A fourth column now shows the kilobytes per second acquired by each channel. It uses the function channel.get_bytes_per_second() added in #1.

**Note**: this doesn't actually show correct data rates - it is still based on the guesses I made for data rates before in the channel class. I've emailed Borja to try to find out the exact definition of each data type.

![snapshot3](https://cloud.githubusercontent.com/assets/5225190/11313929/d928298a-8fd8-11e5-8df1-a9f5b94baee6.png)

It might also be nice to show the total data rate (via DAQmodel.get_bytes_per_second()) but I didn't look into how to pass the message up the tree from a channel to its model, to inform it that a click event has changed a data rate and that the total rate needs updated.
