### PR TITLE
Set correct data acquisition rates

### DIFF
--- a/daq/daqchannel.py
+++ b/daq/daqchannel.py
@@ -16,10 +16,15 @@ class DAQChannelBitrateTooHigh(Exception):
 
 class DAQChannel(object):
     # CDS data types in bytes
+    # from CDS source code function inline static int data_type_size (short dtype)
     TYPEBYTES = {
-        1: 4, # int
-        2: 4, # float
-        4: 2, # short
+        1: 2, # 16 bit int
+        2: 4, # 32 bit int
+        3: 8, # 64 bit int
+        4: 4, # 32 bit float
+        5: 8, # 64 bit double
+        6: 4*2, # 32 bit complex
+        7: 4 # 32 bit uint
     }
   
     def __init__(self, name, channum, model=None, datatype=4,


### PR DESCRIPTION
Gerrit got back to me this morning with a snippet of CDS source code:

``` c
/* numbering must be contiguous */
typedef enum {
  _undefined = 0,
  _16bit_integer = 1,
  _32bit_integer = 2,
  _64bit_integer = 3,
  _32bit_float = 4,
  _64bit_double = 5,
  _32bit_complex = 6,
  _32bit_uint = 7
} daq_data_t;

/* should be equal to the last data type   */
#define MAX_DATA_TYPE _32bit_uint
#define MIN_DATA_TYPE _16bit_integer

inline static int
data_type_size (short dtype) {
  switch (dtype) {
  case _16bit_integer: // 16 bit integer
    return 2;
  case _32bit_integer: // 32 bit integer
  case _32bit_float: // 32 bit float
  case _32bit_uint: // 32 bit unsigned integer
    return 4;
  case _64bit_integer: // 64 bit integer
  case _64bit_double: // 64 bit double
    return 8;
  case _32bit_complex: // 32 bit complex
    return 4*2;
  default:
    return _undefined;
  }
}
```

From this I set the correct data rates used in the acquisition calculations.
